### PR TITLE
fix(ci): decouple init Node from Playwright test Node

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -12,6 +12,10 @@ on:
         type: number
       node:
         type: number
+      test-node:
+        type: number
+        default: 20
+        description: 'Node.js version for Playwright tests (default: 20)'
       qa:
         type: string
         default: 'rete-qa@latest'
@@ -40,7 +44,10 @@ on:
         description: Stack version
       node:
         type: number
-        description: 'Node.js version (default: 16)'
+        description: 'Node.js version for init/build (default: 16)'
+      test-node:
+        type: number
+        description: 'Node.js version for Playwright tests (default: 20)'
       qa:
         description: 'Rete QA (<name>@<version> or <owner>/<repo>#<version>)'
         type: string
@@ -166,13 +173,13 @@ jobs:
         path: .rete-qa
     - uses: actions/setup-node@v3
       with:
-        node-version: ${{ inputs.node || 16 }}
+        node-version: ${{ inputs.test-node || 20 }}
     - name: Cache global node modules
       id: cache-npm
       uses: actions/cache@v3
       with:
         path: ~/.npm
-        key: ${{ runner.os }}-${{ inputs.node || 16 }}-cache-global-node-modules
+        key: ${{ runner.os }}-${{ inputs.test-node || 20 }}-cache-global-node-modules
     - name: Download artifact with Rete QA
       uses: actions/download-artifact@v4
       if: needs.tools.outputs.qa-artifact

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
-        "@playwright/test": "^1.37.1",
+        "@playwright/test": "1.61.1",
         "chalk": "^4.1.1",
         "commander": "^10.0.0",
         "execa": "^5.1.1",
@@ -2695,11 +2695,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
-      "integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.46.1"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8178,11 +8179,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
-      "integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.46.1"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8195,9 +8197,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
-      "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -8210,6 +8213,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rete-kit": "^1.17.0"
   },
   "dependencies": {
-    "@playwright/test": "^1.37.1",
+    "@playwright/test": "1.61.1",
     "chalk": "^4.1.1",
     "commander": "^10.0.0",
     "execa": "^5.1.1",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,20 +1,25 @@
-import { devices } from '@playwright/test'
 import { join } from 'path'
 
 export const dotFolder = '.rete-qa'
 export const appsCachePath = join(dotFolder, 'apps')
 
-export const projects = [
-  {
-    name: 'chromium',
-    use: { ...devices['Desktop Chrome'] }
-  },
-  {
-    name: 'firefox',
-    use: { ...devices['Desktop Firefox'] }
-  },
-  {
-    name: 'webkit',
-    use: { ...devices['Desktop Safari'] }
-  }
-]
+export const projectNames = ['chromium', 'firefox', 'webkit'] as const
+
+export function getProjects() {
+  const { devices } = require('@playwright/test') as typeof import('@playwright/test')
+
+  return [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] }
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { App } from 'rete-kit'
 
 import { fixtures, getFeatures, stackNames, validate } from './commands/init'
 import { validateSnapshotsUpdate, validateTestRun } from './commands/test'
-import { appsCachePath, projects } from './consts'
+import { appsCachePath, projectNames } from './consts'
 import { log } from './ui'
 
 const program = createCommand()
@@ -92,7 +92,7 @@ program
   .option('-g --grep <regex>', 'Match tests by name')
   .option('-s --stack <stack>', `Stacks to test, comma-separated (${stackNames.join(',')})`)
   .option('-sv --stack-versions <stack-version>', `Versions to test, comma-separated`)
-  .option('-p --project <project>', `Project (${projects.map(p => p.name).join(',')})`)
+  .option('-p --project <project>', `Project (${projectNames.join(',')})`)
   .action(async (options: TestOptions) => {
     const stacks = options.stack
       ? options.stack.split(',')

--- a/src/playwright.config.ts
+++ b/src/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test'
 import { join } from 'path'
 
-import { appsCachePath, projects } from './consts'
+import { appsCachePath, getProjects } from './consts'
 
 const { APP, SERVE } = process.env
 
@@ -46,7 +46,7 @@ export default defineConfig({
     trace: 'on-first-retry',
     video: 'on-first-retry'
   },
-  projects,
+  projects: getProjects(),
   outputDir: join(cwd, 'test-results', APP),
   webServer: {
     command: getServeCommand(),


### PR DESCRIPTION
### Description

Lazy-load Playwright in rete-qa init so stack-specific Node versions work for app creation and build. Pin @playwright/test to 1.61.1 and run regression tests on Node 20 via a separate test-node workflow input.

### Related Issues

<!-- If your pull request is related to any GitHub issue(s), mention them here. -->

### Checklist

<!-- Mark the items that apply to this pull request -->

- [ ] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [ ] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

<!-- Any additional information or notes for the reviewers. -->
