### PR TITLE
feat(angular): add support for angular 22

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,12 +11,12 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        version: [21,20,19,18,17,16,15,14,13,12]
+        version: [22,21,20,19,18,17,16,15,14,13,12]
     uses: ./.github/workflows/regression.yml
     with:
       name: angular
       version: ${{ matrix.version }}
-      node: ${{ (matrix.version < 14 && 14) || (matrix.version < 17 && 16) || (matrix.version < 20 && 18) || 20 }}
+      node: ${{ (matrix.version >= 20 && 22) || (matrix.version >= 17 && 18) || (matrix.version >= 14 && 16) || 14 }}
 
   react:
     strategy:

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "globals": "^15.9.0",
     "nodemon": "^2.0.20",
     "rete-cli": "~2.0.1",
-    "rete-kit": "1.17.0",
+    "rete-kit": "^1.19.0",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "rete-kit": "^1.17.0"
+    "rete-kit": "^1.19.0"
   },
   "dependencies": {
     "@playwright/test": "1.61.1",

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -1,10 +1,12 @@
 import { App } from 'rete-kit'
 
+type AngularInitVersion = 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22
+
 export const targets: { stack: App.AppStack, versions: number[] }[] = [
   { stack: 'react', versions: [16, 17, 18] },
   { stack: 'react-vite', versions: [16, 17, 18, 19] },
   { stack: 'vue', versions: [2, 3] },
-  { stack: 'angular', versions: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21] },
+  { stack: 'angular', versions: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22] },
   { stack: 'svelte', versions: [3, 4, 5] },
   { stack: 'lit-vite', versions: [3] }
 ]
@@ -21,7 +23,7 @@ export const fixtures = targets
 
 export function getFeatures({ stack, version }: Pick<(typeof fixtures)[0], 'stack' | 'version'>, next: boolean) {
   return [
-    stack === 'angular' && new App.Features.Angular(version as 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21, next),
+    stack === 'angular' && new App.Features.Angular(version as AngularInitVersion as never, next),
     ['react', 'react-vite'].includes(stack) && new App.Features.React(version, stack, next),
     stack === 'vue' && new App.Features.Vue(version as 2 | 3, next),
     stack === 'svelte' && new App.Features.Svelte(version as 3 | 4 | 5, next),


### PR DESCRIPTION
### Description

Add Angular 22 support to `rete-qa` init and daily regression.

- extend `angular` stack versions with `22`
- update `getFeatures()` for Angular 22 init
- add `22` to daily regression matrix
- use Node 22 for Angular `>= 20` in daily workflow
- require `rete-kit ^1.19.0` (Angular 22 support lands in kit `1.19.0`)

Depends on:
- `rete-kit@^1.19.0` (Angular 22 scaffold/templates)
- published `rete-angular-plugin` with `/22` entrypoint


### Related Issues

https://github.com/retejs/angular-plugin/pull/374
https://github.com/retejs/rete-kit/pull/74

### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).
