### PR TITLE
ci: add build-push workflow for dist branches

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,11 @@
+name: Build and Push
+run-name: Build and Push to dist/${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push:
+    uses: retejs/.github/.github/workflows/build-push.yml@main
+    with:
+      pack_root: true


### PR DESCRIPTION
## Summary

- Adds a manual `workflow_dispatch` workflow to build and push npm package contents to `dist/<branch>` on the current ref.
- Uses the same reusable workflow pattern as rete-kit (`pack_root: true` via `retejs/.github`).
- Enables installing `rete-qa` from dist branches for QA and CI without publishing to npm.

## Test plan

- [ ] Merge and run **Build and Push** from a test branch; confirm `dist/<branch>` is updated on the remote.


Made with [Cursor](https://cursor.com)